### PR TITLE
Delete list

### DIFF
--- a/backend/prisma/migrations/20250508080610_cascade_delete_ingredients/migration.sql
+++ b/backend/prisma/migrations/20250508080610_cascade_delete_ingredients/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Ingredient" DROP CONSTRAINT "Ingredient_recipeId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Ingredient" ADD CONSTRAINT "Ingredient_recipeId_fkey" FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -64,7 +64,7 @@ model Ingredient {
   id          String @id @default(uuid())
   name        String // e.g. "chicken breast"
   servingSize Int // amount in grams
-  recipe      Recipe @relation(fields: [recipeId], references: [id])
+  recipe      Recipe @relation(fields: [recipeId], references: [id], onDelete: Cascade)
   recipeId    String
   calories    Float
   protein     Float

--- a/backend/routers/recipelistsRouter.js
+++ b/backend/routers/recipelistsRouter.js
@@ -49,10 +49,6 @@ router.get('/api/recipelists/user/:userId', async (req, res) => {
   const { userId } = req.params;
   try {
     const recipeLists = await prisma.recipeList.findMany({
-      cacheStrategy: {
-        ttl: 30,
-        swr: 60
-      },
       where: { userId: userId },
       include: {
         recipes: {
@@ -91,6 +87,30 @@ router.post('/api/recipelists', async (req, res) => {
     res.status(201).send({ status: 201, data: recipeList });
   } catch (error) {
     console.error('Error adding recipe list:', error);
+    res.status(500).send({ message: error.message });
+  }
+});
+
+router.delete('/api/recipelists/:listId', async (req, res) => {
+  const { listId } = req.params;
+  if (!listId) {
+    return res.status(400).send({ errorMessage: 'List ID is required' });
+  }
+  try {
+    await prisma.recipe.deleteMany({
+      where: {
+        recipeLists: {
+          some: { id: listId }
+        }
+      }
+    });
+
+    const deletedRecipeList = await prisma.recipeList.delete({
+      where: { id: listId },
+    });
+    res.status(200).send({ status: 200, data: deletedRecipeList });
+  } catch (error) {
+    console.error('Error deleting recipe list:', error);
     res.status(500).send({ message: error.message });
   }
 });

--- a/frontend/src/lib/api/recipelistApi.js
+++ b/frontend/src/lib/api/recipelistApi.js
@@ -52,9 +52,27 @@ const getRecipelistByListId = async (listId) => {
   return data;
 }
 
+const deleteRecipeList = async (listId) => {
+  const response = await fetch(`${BASE_URL}/${listId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to delete recipe list');
+  }
+
+  const data = await response.json();
+  return data;
+}
+
 export {
   addRecipeList,
   getRecipeListsByUserId,
-  getRecipelistByListId
+  getRecipelistByListId,
+  deleteRecipeList,
 };
 

--- a/frontend/src/lib/components/delete-list-dialog/delete-list-dialog.svelte
+++ b/frontend/src/lib/components/delete-list-dialog/delete-list-dialog.svelte
@@ -1,0 +1,44 @@
+<script>
+  import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
+  import { Button, buttonVariants } from "$lib/components/ui/button/index.js";
+  import { X } from "lucide-svelte";
+  import AlertDialogAction from "../ui/alert-dialog/alert-dialog-action.svelte";
+  import { deleteRecipeList } from "$lib/api/recipelistApi";
+  import { toast } from "svelte-sonner";
+
+  let { selectedList = $bindable(), recipeLists = $bindable() } = $props();
+  let isDialogOpen = $state(false);
+
+  const handleDelete = async () => {
+  try {
+    await deleteRecipeList(selectedList.id);
+    toast.success('List deleted successfully!'); // Update success message
+    isDialogOpen = false;
+    recipeLists = recipeLists.filter(list => list.id !== selectedList.id); // Remove the deleted list from the recipeLists
+    selectedList = recipeLists[0] || null; // Set selectedList to the first one or null if none left
+    console.log($state.snapshot(recipeLists));
+  } catch (error) {
+    console.error(error);
+    toast.error('Failed to delete the recipe. Please try again.');
+  }
+}
+  
+ </script>
+  
+ <AlertDialog.Root bind:open={isDialogOpen}>
+  <AlertDialog.Trigger class="opacity-0 group-hover:opacity-100 duration-200 m-1 transition-all rounded-md">
+  <X class="h-5 w-5 hover:text-destructive transition-colors" />
+  </AlertDialog.Trigger>
+  <AlertDialog.Content>
+   <AlertDialog.Header>
+    <AlertDialog.Title>Delete this list?</AlertDialog.Title>
+    <AlertDialog.Description>
+     This action cannot be undone.<br> This will permanently delete the list from the system.
+    </AlertDialog.Description>
+   </AlertDialog.Header>
+   <AlertDialog.Footer>
+    <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+    <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={handleDelete}>Delete</AlertDialog.Action>
+   </AlertDialog.Footer>
+  </AlertDialog.Content>
+ </AlertDialog.Root>

--- a/frontend/src/routes/recipes/+page.svelte
+++ b/frontend/src/routes/recipes/+page.svelte
@@ -9,6 +9,7 @@
   import AddRecipeDialog from "$lib/components/add-recipe-dialog/add-recipe-dialog.svelte";
   import { getCategories } from "$lib/api/categoryApi.js";
   import { LoaderCircle } from "lucide-svelte";
+  import DeleteListDialog from "$lib/components/delete-list-dialog/delete-list-dialog.svelte";
 
   const { data } = $props();
   const { user } = data;
@@ -72,8 +73,13 @@
       </div>
 
     {:else if selectedList}
-      <div class="flex items-center justify-between mb-4">
-        <h1 class="text-2xl font-bold">{selectedList.name}</h1>
+      <div class="group flex items-center justify-between mb-4">
+        <div class="relative">
+          <h1 class="text-2xl font-bold">{selectedList.name}</h1>
+          <div class="absolute -top-1 -right-7">
+        <DeleteListDialog bind:selectedList bind:recipeLists />
+          </div>
+        </div>
         <AddRecipeDialog bind:selectedList {categories} />
       </div>
 


### PR DESCRIPTION
This pull request introduces cascading delete functionality for `Ingredient` entities, removes caching from a specific API route, and implements a feature for deleting recipe lists, including backend API support and frontend UI integration.

### Database and Schema Updates:
* Updated the `Ingredient` table to enable cascading deletes when a related `Recipe` is deleted. This includes modifying the foreign key constraint in `migration.sql` and adding the `onDelete: Cascade` directive in the Prisma schema. [[1]](diffhunk://#diff-3a3e12f37e73432e4bbcbbe83374219a999042288151c2ee1fcfab1e7aa8b65dR1-R5) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL67-R67)

### Backend API Changes:
* Removed the caching strategy from the `GET /api/recipelists/user/:userId` route to simplify query behavior.
* Added a new `DELETE /api/recipelists/:listId` route to handle the deletion of recipe lists, including cleanup of associated recipes.

### Frontend API and Component Updates:
* Added a `deleteRecipeList` function in `recipelistApi.js` to call the new backend API endpoint for deleting recipe lists.
* Created a new `DeleteListDialog` Svelte component to provide a confirmation dialog for deleting recipe lists, with UI feedback for success or failure.
* Integrated the `DeleteListDialog` component into the `+page.svelte` file for the recipes page, allowing users to delete lists directly from the UI. [[1]](diffhunk://#diff-81d311352123718d505c288b49ad1b1f9a851abdbf987c27ae29b037eed9b679R12) [[2]](diffhunk://#diff-81d311352123718d505c288b49ad1b1f9a851abdbf987c27ae29b037eed9b679L75-R82)