### PR TITLE
added switch to toggle email notifications

### DIFF
--- a/backend/prisma/migrations/20250517132442_add_notification_bools/migration.sql
+++ b/backend/prisma/migrations/20250517132442_add_notification_bools/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "alertNotifications" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "emailNotifications" BOOLEAN NOT NULL DEFAULT true;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,18 +15,21 @@ datasource db {
 }
 
 model User {
-  id          String    @id @default(uuid())
-  username    String    @unique
-  email       String    @unique
+  id          String   @id @default(uuid())
+  username    String   @unique
+  email       String   @unique
   password    String
   avatar      Bytes?
   avatarMime  String?
-  isConfirmed Boolean   @default(false)
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  
-  following  User[]  @relation("UserFollows")
-  followers  User[]  @relation("UserFollows")
+  isConfirmed Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  emailNotifications Boolean @default(true)
+  alertNotifications Boolean @default(true)
+
+  following User[] @relation("UserFollows")
+  followers User[] @relation("UserFollows")
 
   comments    Comment[]
   recipeLists RecipeList[]

--- a/backend/repository/commentsRepository.js
+++ b/backend/repository/commentsRepository.js
@@ -136,7 +136,8 @@ const postCommentReply = async (userId, text, recipeId, commentParentId) => {
             include: {
                 user: {
                     select: {
-                        username: true
+                      username: true,
+                      emailNotifications: true
                     }
                 }
             }

--- a/backend/sockets/socketHandlers/commentsHandler.js
+++ b/backend/sockets/socketHandlers/commentsHandler.js
@@ -10,7 +10,11 @@ export const commentsHandler = (socket, io) => {
         
         const recipeCreatorUsername = postedComment.recipe.recipeLists[0].user.username;
         const recipeCreatorEmail = postedComment.recipe.recipeLists[0].user.email;
-        emailService.sendCommentNotification(recipeCreatorEmail, recipeCreatorUsername, postedComment);
+      
+        const emailNotificationEnabled = postedComment.recipe.recipeLists[0].user.emailNotifications;
+        if (emailNotificationEnabled) {
+          emailService.sendCommentNotification(recipeCreatorEmail, recipeCreatorUsername, postedComment);
+      };
 
         io.emit("new-comment", postedComment);
         
@@ -31,8 +35,13 @@ export const commentsHandler = (socket, io) => {
         } else {
             const foundRecipe = await recipeRepository.getRecipeById(newReply.recipeId);
             const recipeName = foundRecipe.name;
-            newReply.replyParent.recipe = { name: recipeName};
-            emailService.sendCommentReplyNotification(newReply.replyParent, postedCommentReply);
+          newReply.replyParent.recipe = { name: recipeName };
+          
+            const emailsNotificationEnabled = postedCommentReply.user.emailNotifications;
+            if (emailsNotificationEnabled) {
+              emailService.sendCommentReplyNotification(newReply.replyParent, postedCommentReply);    
+          };
+            
         }
 
         io.emit("new-comment-reply", postedCommentReply);

--- a/frontend/src/lib/api/userApi.js
+++ b/frontend/src/lib/api/userApi.js
@@ -32,6 +32,13 @@ const getUsersByPartialUsername = async (query) => {
   return data;
 }
 
+const updateUser = async (user) => {
+  const option = makeOption("PUT", user);
+  const response = await fetchWithAuth(`${BASE_URL}`, option);
+  const data = await response.json();
+  return data;
+}
+
 const changeUsername = async (userId, newUsername) => {
   const option = makeOption("PATCH", { userId, newUsername });
   const response = await fetchWithAuth(`${BASE_URL}`, option);
@@ -72,6 +79,7 @@ const deleteUser = async (userId) => {
 export {
   getUserById,
   getUsersByPartialUsername,
+  updateUser,
   changeUsername,
   changePassword,
   deleteUser,

--- a/frontend/src/routes/settings/notifications/+page.svelte
+++ b/frontend/src/routes/settings/notifications/+page.svelte
@@ -4,19 +4,29 @@
   import * as Card from "$lib/components/ui/card/index.js";
   import { Checkbox } from "$lib/components/ui/checkbox/index.js";
   import { toast } from "svelte-sonner";
+  import { onMount } from "svelte";
+  import { getUserById, updateUser } from "$lib/api/userApi";
 
-  let emailNotifications = $state(false);
-  let alertNotifications = $state(false);
+  let { data } = $props();
+  let userId = data.user.id;
+  let user = $state({});
+  let emailNotifications = $state(true);
 
-  const toggleEmailNotifications = () => {
-    toast.info("Feature coming soon!");
-    // Call API to update email notifications setting
-  };
+  const saveSettings = async () => {
+    user.emailNotifications = emailNotifications;
+    let response = await updateUser( {user} );
 
-  const toggleAlertNotifications = () => {
-    toast.info("Feature coming soon!");
-    // Call API to update alert notifications setting
-  };
+    if (response.status !== 200) {
+      toast.error("Failed to save settings.");
+      return;
+    }
+    toast.success("Settings saved successfully!");
+  }
+
+  onMount(async () => {
+    user = await getUserById(userId);
+    emailNotifications = user.emailNotifications;
+  });
 
 </script>
 
@@ -29,18 +39,9 @@
   </Card.Header>
   <Card.Content class="flex items-center justify-between py-4">
     <span class="text-base">Receive email notifications</span>
-    <Switch bind:checked={emailNotifications} onchange={toggleEmailNotifications} />
+    <Switch bind:checked={emailNotifications} on:change={toggleEmailNotifications} />
   </Card.Content>
 </Card.Root>
-<Card.Root class="col-span-5">
-  <Card.Header>
-    <Card.Title>Alert Notifications</Card.Title>
-    <Card.Description>
-      Enable or disable alert notifications for your account.
-    </Card.Description>
-  </Card.Header>
-  <Card.Content class="flex items-center justify-between py-4">
-    <span class="text-base">Receive alert notifications</span>
-    <Switch bind:checked={alertNotifications} onchange={toggleAlertNotifications} />
-  </Card.Content>
-</Card.Root>
+
+
+<Button class="col-span-2 col-start-1" onclick={saveSettings}>Save Settings</Button>


### PR DESCRIPTION
This pull request introduces a feature to manage user notification preferences, specifically email notifications, across the backend and frontend. Key changes include updates to the database schema, backend routes, and frontend components to enable users to toggle their email notification settings.

### Backend Changes:

* **Database Schema Updates**:
  - Added `emailNotifications` and `alertNotifications` columns to the `User` table with a default value of `true`. (`backend/prisma/migrations/20250517132442_add_notification_bools/migration.sql`, `backend/prisma/schema.prisma`) [[1]](diffhunk://#diff-556186d1a2fe68e6d07f054f6ff3a2149ee901309019d07adec272066081aab3R1-R3) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR28-R30)

* **API Enhancements**:
  - Updated the `usersRouter` to include a new `PUT` route for updating user details, including `emailNotifications`. (`backend/routers/usersRouter.js`)
  - Modified the `PATCH` route to allow partial updates, including `emailNotifications`. (`backend/routers/usersRouter.js`)

* **Notification Logic**:
  - Integrated `emailNotifications` checks into the comment and reply notification logic to ensure emails are only sent if the user has enabled this setting. (`backend/sockets/socketHandlers/commentsHandler.js`) [[1]](diffhunk://#diff-efea5f000cd8a5331479a2cc6eb9c8f5db61eac5aefb40dc7be1f139a6f3e2c2R13-R17) [[2]](diffhunk://#diff-efea5f000cd8a5331479a2cc6eb9c8f5db61eac5aefb40dc7be1f139a6f3e2c2R39-R44)

### Frontend Changes:

* **API Integration**:
  - Added an `updateUser` function to the user API for updating user details. (`frontend/src/lib/api/userApi.js`) [[1]](diffhunk://#diff-54ff17566b8ac11609c085912f04847be77c655b0e8c976fcd523683f28992e7R35-R41) [[2]](diffhunk://#diff-54ff17566b8ac11609c085912f04847be77c655b0e8c976fcd523683f28992e7R82)

* **Notification Settings Page**:
  - Updated the `notifications` page to fetch the current user's notification preferences and allow toggling `emailNotifications`. Added a "Save Settings" button to persist changes. (`frontend/src/routes/settings/notifications/+page.svelte`) [[1]](diffhunk://#diff-a8c19477cb34c6d022e62b04aacf9bb2f5f7e56ff7531b01f7cafb8cb9e8e120R7-R29) [[2]](diffhunk://#diff-a8c19477cb34c6d022e62b04aacf9bb2f5f7e56ff7531b01f7cafb8cb9e8e120L32-R47)