### PR TITLE
deleting recipe deletes image too

### DIFF
--- a/backend/service/b2FileUploadService.js
+++ b/backend/service/b2FileUploadService.js
@@ -109,8 +109,40 @@ const handleB2Upload = async (imageUrl) => {
   return b2ImagePath;
 }
 
+const deleteFile = async (fileName) => {
+  try {
+    await authorize();
+    const bucketId = process.env.BACKBLAZE_BUCKET_ID;
+
+    // List file versions to get the fileId
+    const listResponse = await b2Client.listFileNames({
+      bucketId,
+      prefix: fileName,
+      maxFileCount: 1
+    });
+
+    const file = listResponse.data.files.find(f => f.fileName === fileName);
+    if (!file) {
+      throw new Error('File not found in Backblaze B2');
+    }
+
+    // Delete the file version
+    await b2Client.deleteFileVersion({
+      fileName: file.fileName,
+      fileId: file.fileId
+    });
+
+    console.log('File deleted successfully:', fileName);
+    return true;
+  } catch (error) {
+    console.error('Error deleting file from Backblaze B2:', error);
+    throw error;
+  }
+};
+
 const b2 = {
-  handleB2Upload
+  handleB2Upload,
+  deleteFile
 }
 
 export default b2;


### PR DESCRIPTION
This pull request introduces functionality to delete associated comments and images when a recipe is deleted, along with adding a new method for deleting files from Backblaze B2 storage. The changes improve data consistency and resource cleanup during recipe deletion.

### Recipe Deletion Enhancements:
* [`backend/routers/recipesRouter.js`](diffhunk://#diff-b9c4ba333e18a7574e9947ce3ef916e59e0eaf091d03371729975870ced7a4b0R183-R196): Added logic to delete all comments associated with a recipe when it is removed. Also, if the recipe has an associated image, it extracts the file name from the image URL and deletes the image from Backblaze B2 storage using the new `deleteFile` method.

### Backblaze B2 Integration:
* [`backend/service/b2FileUploadService.js`](diffhunk://#diff-74e8a8ac469f78b1defc83fbd62059cb94717f0577bc1af9488a01dcb20070ceR112-R145): Introduced the `deleteFile` method to handle deletion of files from Backblaze B2 storage. This method retrieves the file ID using the file name and deletes the corresponding file version.

### Code Cleanup:
* [`backend/routers/recipesRouter.js`](diffhunk://#diff-b9c4ba333e18a7574e9947ce3ef916e59e0eaf091d03371729975870ced7a4b0L172): Removed an unnecessary `console.log` statement from the `DELETE /api/recipes/:id` route handler.

### Dependency Updates:
* [`backend/routers/recipesRouter.js`](diffhunk://#diff-b9c4ba333e18a7574e9947ce3ef916e59e0eaf091d03371729975870ced7a4b0R5): Imported the `b2FileUploadService` module to enable file deletion functionality.