### PR TITLE
Capitalised remaining Components

### DIFF
--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,9 +1,9 @@
 <script>
-  import Authform from '$lib/components/AuthForm/AuthForm.svelte';
+  import AuthForm from '$lib/components/AuthForm/AuthForm.svelte';
 </script>
 
 <svelte:head>
   <title>InstaRecipe | Login</title>
 </svelte:head>
 
-<Authform />
+<AuthForm />

--- a/frontend/src/routes/settings/+layout.svelte
+++ b/frontend/src/routes/settings/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-  import Navlink from '$lib/components/Navbar/NavLink.svelte';
+  import NavLink from '$lib/components/Navbar/NavLink.svelte';
 
   let { data, children } = $props();
 
@@ -20,8 +20,8 @@
   >
     <nav class="text-muted-foreground grid gap-4 text-sm"
       data-x-chunk-container="chunk-container after:right-0">
-      <Navlink href="/settings/general" exact={true} >General</Navlink>
-      <Navlink href="/settings/notifications" exact={true} >Notifications</Navlink>
+      <NavLink href="/settings/general" exact={true} >General</NavLink>
+      <NavLink href="/settings/notifications" exact={true} >Notifications</NavLink>
     </nav>
     <div class="grid grid-cols-8 gap-6">
       {@render children()}


### PR DESCRIPTION
This pull request addresses inconsistencies in component naming by standardizing the capitalization of component imports and usage across the codebase. Specifically, it ensures that component names follow PascalCase conventions for better readability and consistency.

### Standardization of component naming:

* [`frontend/src/routes/login/+page.svelte`](diffhunk://#diff-4cf858ba0db6771653a24a39dadf34e970582054612bea1ed92200cbd300a93eL2-R9): Corrected the import and usage of the `AuthForm` component to use PascalCase (`Authform` → `AuthForm`).
* [`frontend/src/routes/settings/+layout.svelte`](diffhunk://#diff-1c5b2e36dd5692cc8d0c79c1b5b315b84caf59af2767958b078d31683f5d607aL2-R2): Updated the import and usage of the `NavLink` component to use PascalCase (`Navlink` → `NavLink`). This change was applied both to the import statement and to multiple instances of the component usage. [[1]](diffhunk://#diff-1c5b2e36dd5692cc8d0c79c1b5b315b84caf59af2767958b078d31683f5d607aL2-R2) [[2]](diffhunk://#diff-1c5b2e36dd5692cc8d0c79c1b5b315b84caf59af2767958b078d31683f5d607aL23-R24)