### PR TITLE
changed dashboard to explore

### DIFF
--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -24,7 +24,7 @@ async function authenticateToken(req, res, next) {
     }
 }
 
-//burde kun bruges på /api/login, hvis man allerede er logget ind, og man clicker login burde man blive redirected direkte til dashboard.
+//burde kun bruges på /api/login, hvis man allerede er logget ind, og man clicker login burde man blive redirected direkte til explore.
 async function isAuthenticated(req, res, next) {
     try{
         const jwt = req.cookies.jwt;

--- a/frontend/src/lib/components/navbar/navbar.svelte
+++ b/frontend/src/lib/components/navbar/navbar.svelte
@@ -117,7 +117,7 @@
       class="hidden flex-col gap-6 md:flex md:flex-row md:items-center md:gap-5 lg:gap-6"
     >
       <a
-        href={$isAuthenticated ? "/dashboard" : "/"}
+        href={$isAuthenticated ? "/explore" : "/"}
         class="flex items-center gap-2 text-lg font-semibold md:text-base"
       >
         <CookingPot class="h-6 w-6" />InstaRecipe
@@ -125,10 +125,11 @@
       {#if !$isAuthenticated}
         <Navlink exact={true} href="/">Home</Navlink>
       {:else}
-        <Navlink exact={true} href="/dashboard">Dashboard</Navlink>
+        <Navlink exact={true} href="/explore">Explore</Navlink>
         <Navlink href="/users/recipes">Recipes</Navlink>
       {/if}
     </nav>
+    
     <Sheet.Root>
       <Sheet.Trigger let:props>
         {#snippet child({ props })}
@@ -149,12 +150,13 @@
             <CookingPot class="h-6 w-6" />
             <span class="sr-only">InstaRecipe</span>
           </a>
-          <Navlink href="/dashboard" class="text-muted-foreground hover:text-foreground"> Dashboard </Navlink>
+          <Navlink href="/explore" class="text-muted-foreground hover:text-foreground"> Explore </Navlink>
           <Navlink href="/recipes" class="text-muted-foreground hover:text-foreground"> Recipes </Navlink>
           <Navlink href="/settings/general" class="hover:text-foreground"> Settings </Navlink>
         </nav>
       </Sheet.Content>
     </Sheet.Root>
+    
     <div class="flex w-full items-center gap-4 md:ml-auto md:gap-2 lg:gap-4">
       <div class="ml-auto flex-1 sm:flex-initial">
         {#if !$isAuthenticated}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -7,8 +7,8 @@
   onMount(() => {
     // Check if the user is authenticated
     if ($isAuthenticated) {
-      // If so, redirect to the dashboard page
-      goto("/dashboard");
+      // If so, redirect to the explore page
+      goto("/explore");
     }
   });
 </script>

--- a/frontend/src/routes/explore/+page.svelte
+++ b/frontend/src/routes/explore/+page.svelte
@@ -43,7 +43,7 @@
 </script>
 
 <svelte:head>
-  <title>InstaRecipe | Dashboard</title>
+  <title>InstaRecipe | explore</title>
 </svelte:head>
 
 <div class="flex flex-col p-10">

--- a/frontend/src/routes/login/+page.server.js
+++ b/frontend/src/routes/login/+page.server.js
@@ -2,10 +2,10 @@ import { redirect } from '@sveltejs/kit';
 
 export function load({ locals, url }) {
   if (locals.user) {
-    // user is already authenticated → short-circuit to /dashboard
-    throw redirect(303, '/dashboard');
+    // user is already authenticated → short-circuit to /explore
+    throw redirect(303, '/explore');
   }
   
-  const returnTo = url.searchParams.get('returnTo') || '/dashboard';
+  const returnTo = url.searchParams.get('returnTo') || '/explore';
   return { url: url.pathname, returnTo };
 }

--- a/frontend/src/routes/verify/[id]/+page.svelte
+++ b/frontend/src/routes/verify/[id]/+page.svelte
@@ -22,7 +22,7 @@
       
       setTimeout(() => {
         updateAuthState(user);
-        goto("/dashboard");
+        goto("/explore");
       }, 3000);
      
     } catch (error) {
@@ -43,7 +43,7 @@
   {:else if status === 'success'}
     <h1 class="font-bold text-3xl text-center text-green-600">Email verified successfully!</h1>
     <p class="mt-4 text-center dark:text-gray-200">{message}</p>
-    <p class="mt-2 text-center dark:text-gray-200">Redirecting to dashboard...</p>
+    <p class="mt-2 text-center dark:text-gray-200">Redirecting to explore...</p>
   {:else}
     <h1 class="font-bold text-3xl text-center text-red-600">Verification failed</h1>
     <p class="mt-4 text-center dark:text-gray-200">{message}</p>


### PR DESCRIPTION
This pull request updates the application to replace references to the "Dashboard" page with the "Explore" page across both the frontend and backend. The changes ensure a consistent user experience by redirecting authenticated users to the "Explore" page and updating navigation links, titles, and messages accordingly.

### Frontend Changes:

* **Navigation Updates:**
  - Updated navigation links in `navbar.svelte` to replace "/dashboard" with "/explore" for authenticated users. [[1]](diffhunk://#diff-3d726dda6606a053315810d61c97fb66bcde9d6dc64315cecc060d5c67268031L120-R132) [[2]](diffhunk://#diff-3d726dda6606a053315810d61c97fb66bcde9d6dc64315cecc060d5c67268031L152-R159)

* **Redirect Logic:**
  - Modified `+page.svelte` in the root route to redirect authenticated users to "/explore" instead of "/dashboard".
  - Updated `+page.server.js` in the login route to redirect authenticated users to "/explore" and set the default `returnTo` parameter to "/explore".
  - Adjusted the email verification page in `verify/[id]/+page.svelte` to redirect users to "/explore" after successful verification. ([frontend/src/routes/verify/[id]/+page.svelteL25-R25](diffhunk://#diff-e3c07eba1611ace1cee62a8fbbe82ebdf4a5d1b1267d7c59d90cf922045a05feL25-R25))

* **Page Renaming and Titles:**
  - Renamed the `dashboard` route to `explore` and updated the page title in `explore/+page.svelte` to reflect the change.

### Backend Changes:

* **Middleware Comment Update:**
  - Updated a comment in `authMiddleware.js` to reflect the change in redirection from "dashboard" to "explore".