### PR TITLE
made authRouter follow REST conventions

### DIFF
--- a/backend/routers/authRouter.js
+++ b/backend/routers/authRouter.js
@@ -24,6 +24,29 @@ const cookieOptions = {
 };
 
 
+router.get("/api/auth/verify/:id", async (req, res) => {
+  const id = req.params.id;
+
+  try {
+    const updatedUser = await prisma.user.update({
+      where: {
+        id: id,
+      },
+      data: {
+        isConfirmed: true,
+      },
+    });
+
+    const { password: _, ...userWithoutPassword } = updatedUser;
+    const token = await authService.generateToken(userWithoutPassword);
+
+    return res.cookie("jwt", token, cookieOptions).send({ data: userWithoutPassword });
+
+  } catch (error) {
+    console.error(error);
+    res.status(500).send({ errorMessage: "Something went wrong confirming the email." });
+  }
+});
 
 router.post("/api/auth/register", async (req, res) => {
   const { username, email, password } = req.body;
@@ -201,28 +224,5 @@ router.patch("/api/auth/reset-password/:token", async (req, res) => {
   }
 });
 
-router.get("/api/auth/verify/:id", async (req, res) => {
-  const id = req.params.id;
-
-  try {
-    const updatedUser = await prisma.user.update({
-      where: {
-        id: id,
-      },
-      data: {
-        isConfirmed: true,
-      },
-    });
-
-    const { password: _, ...userWithoutPassword } = updatedUser;
-    const token = await authService.generateToken(userWithoutPassword);
-
-    return res.cookie("jwt", token, cookieOptions).send({ data: userWithoutPassword });
-
-  } catch (error) {
-    console.error(error);
-    res.status(500).send({ errorMessage: "Something went wrong confirming the email." });
-  }
-});
 
 export default router;


### PR DESCRIPTION
This pull request refactors the `/api/auth/verify/:id` endpoint in the `authRouter.js` file by relocating it within the file for better organization and clarity. No functional changes were made to the endpoint's logic.

### Refactoring for code organization:

* Moved the `/api/auth/verify/:id` endpoint from the bottom of the file to an earlier position, just above the `/api/auth/register` endpoint, to improve logical grouping of authentication-related routes. [[1]](diffhunk://#diff-0f9f556ed295935d190383858854ba9b30c6b6c168a6e60b1eac98f44acfcf75R27-R49) [[2]](diffhunk://#diff-0f9f556ed295935d190383858854ba9b30c6b6c168a6e60b1eac98f44acfcf75L204-L226)