### PR TITLE
added path for /register back into the code

### DIFF
--- a/frontend/src/lib/components/Authform/Authform.svelte
+++ b/frontend/src/lib/components/Authform/Authform.svelte
@@ -7,8 +7,12 @@
   import Loginform from '../Loginform/Loginform.svelte';
   import Registerform from '../Registerform/Registerform.svelte';
 
-  const { returnTo } = $props();
+  const { returnTo, isRegister } = $props();
   let loginMode = $state(true);
+
+  if(isRegister) {
+    loginMode = false;
+  }
 
   const handleToggleAuthMode = () => {
     loginMode = !loginMode;

--- a/frontend/src/lib/components/Loginform/Loginform.svelte
+++ b/frontend/src/lib/components/Loginform/Loginform.svelte
@@ -55,7 +55,7 @@
 
       updateAuthState(data, accessToken);
       
-      goto(returnTo);
+      goto(returnTo ? returnTo : '/explore');
       toast.success('Login successful!');
       
     } catch (error) {

--- a/frontend/src/routes/register/+page.svelte
+++ b/frontend/src/routes/register/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+  import Authform from '$lib/components/Authform/Authform.svelte';
+  const isRegister = true;
+  
+</script>
+
+<svelte:head>
+  <title>InstaRecipe | Register</title>
+</svelte:head>
+
+<Authform {isRegister}/>


### PR DESCRIPTION
This pull request introduces updates to the authentication flow in the frontend, focusing on enabling a dedicated registration page and improving navigation behavior after login. Key changes include adding support for a registration mode in the `Authform` component, updating the login redirection logic, and creating a new registration page.

### Enhancements to authentication flow:

* **`Authform.svelte`:** Added a new `isRegister` prop to determine whether the form should start in registration mode. If `isRegister` is true, the `loginMode` is set to `false` by default.

* **`Loginform.svelte`:** Updated the navigation logic after login to redirect to `/explore` if the `returnTo` parameter is not provided.

### New registration page:

* **`+page.svelte`:** Created a new registration page that uses the `Authform` component with the `isRegister` prop set to true, along with a custom title for the page.